### PR TITLE
Allow the administrating database role to be configured dynamically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/supabase/auth/badge.svg?branch=master)](https://coveralls.io/github/supabase/auth?branch=master)
 
+## Cepro Docker build NOTE
+
+Build for Linux (amd64) and Mac (arm64):
+```sh
+docker buildx create --name multiarch --driver docker-container --use
+docker buildx inspect --bootstrap
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/cepro/supabase-auth:v2.177.0 --push .
+```
+
 Auth is a user management and authentication server written in Go that powers
 [Supabase](https://supabase.com)'s features such as:
 

--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -67,6 +67,7 @@ func migrate(cmd *cobra.Command, args []string) {
 	deets.Options = map[string]string{
 		"migration_table_name": "schema_migrations",
 		"Namespace":            globalConfig.DB.Namespace,
+		"AdminRole":            globalConfig.DB.AdminRole,
 	}
 
 	db, err := pop.NewConnection(deets)

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -85,6 +85,7 @@ type DBConfiguration struct {
 	Driver    string `json:"driver" required:"true"`
 	URL       string `json:"url" envconfig:"DATABASE_URL" required:"true"`
 	Namespace string `json:"namespace" envconfig:"DB_NAMESPACE" default:"auth"`
+	AdminRole string `json:"admin_role" envconfig:"DB_ADMIN_ROLE" default:"postgres"`
 	// MaxPoolSize defaults to 0 (unlimited).
 	MaxPoolSize       int           `json:"max_pool_size" split_words:"true"`
 	MaxIdlePoolSize   int           `json:"max_idle_pool_size" split_words:"true"`

--- a/migrations/20240612123726_enable_rls_update_grants.up.sql
+++ b/migrations/20240612123726_enable_rls_update_grants.up.sql
@@ -16,21 +16,21 @@ do $$ begin
     alter table {{ index .Options "Namespace" }}.flow_state enable row level security;
     alter table {{ index .Options "Namespace" }}.identities enable row level security;
     alter table {{ index .Options "Namespace" }}.one_time_tokens enable row level security;
-    -- allow postgres role to select from auth tables and allow it to grant select to other roles
-    grant select on {{ index .Options "Namespace" }}.schema_migrations to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.instances to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.users to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.audit_log_entries to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.saml_relay_states to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.refresh_tokens to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.mfa_factors to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.sessions to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.sso_providers to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.sso_domains to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.mfa_challenges to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.mfa_amr_claims to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.saml_providers to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.flow_state to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.identities to postgres with grant option;
-    grant select on {{ index .Options "Namespace" }}.one_time_tokens to postgres with grant option;
+    -- allow admin role (normally "postgres") to select from auth tables and allow it to grant select to other roles
+    grant select on {{ index .Options "Namespace" }}.schema_migrations to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.instances to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.users to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.audit_log_entries to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.saml_relay_states to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.refresh_tokens to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.mfa_factors to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.sessions to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.sso_providers to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.sso_domains to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.mfa_challenges to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.mfa_amr_claims to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.saml_providers to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.flow_state to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.identities to {{ index .Options "AdminRole" }} with grant option;
+    grant select on {{ index .Options "Namespace" }}.one_time_tokens to {{ index .Options "AdminRole" }} with grant option;
 end $$;


### PR DESCRIPTION
Currently the administrating role is hardcoded as 'postgres' in the migrations. This works in most situations, but when using a managed database service sometimes it's neccesary to use alternative roles.